### PR TITLE
Simple traits poc

### DIFF
--- a/src/__test__/types.ts
+++ b/src/__test__/types.ts
@@ -1,6 +1,6 @@
 import { ConcreteType, Type } from "../typecheck/type";
 
-const BASICS_MODULE = "Basics";
+export const BASICS_MODULE = "Basics";
 
 export const Int: ConcreteType = {
   moduleName: BASICS_MODULE,

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "vitest";
 import { CompileOptions, Compiler, compileProject } from "./compiler";
-import { TypedModule, typecheck, typecheckProject } from "../typecheck";
+import {
+  TypedModule,
+  resetTraitsRegistry,
+  typecheck,
+  typecheckProject,
+} from "../typecheck";
 import { UntypedModule, unsafeParse } from "../parser";
-import { defaultTraitImpls } from "../typecheck/defaultImports";
 
 test("compile int constants", () => {
   const out = compileSrc(`pub let x = 42`);
@@ -1520,17 +1524,18 @@ Main$main.exec();
 function compileSrc(src: string, ns?: string) {
   const parsed = unsafeParse(src);
   ns = ns ?? "Main";
-  const [program] = typecheck(ns, parsed, {}, [], [], testEntryPoint.type);
+  resetTraitsRegistry();
+  const [program] = typecheck(ns, parsed, {}, [], testEntryPoint.type);
   const out = new Compiler().compile(program, ns);
   return out;
 }
 
 // Returns Main
 function compileSrcWithDeps(rawProject: Record<string, string>): string {
+  resetTraitsRegistry();
   const res = typecheckProject(
     parseProject(rawProject),
     [],
-    defaultTraitImpls,
     testEntryPoint.type,
   );
   const Main = res.Main!;
@@ -1565,11 +1570,11 @@ function compileRawProject(
   rawProject: Record<string, string>,
   options: CompileOptions = { entrypoint: testEntryPoint },
 ): string {
+  resetTraitsRegistry();
   const untypedProject = parseProject(rawProject);
   const typecheckResult = typecheckProject(
     untypedProject,
     [],
-    defaultTraitImpls,
     testEntryPoint.type,
   );
 

--- a/src/compiler/compiler.test.ts
+++ b/src/compiler/compiler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { CompileOptions, Compiler, compileProject } from "./compiler";
 import { TypedModule, typecheck, typecheckProject } from "../typecheck";
 import { UntypedModule, unsafeParse } from "../parser";
+import { defaultTraitImpls } from "../typecheck/defaultImports";
 
 test("compile int constants", () => {
   const out = compileSrc(`pub let x = 42`);
@@ -1519,7 +1520,7 @@ Main$main.exec();
 function compileSrc(src: string, ns?: string) {
   const parsed = unsafeParse(src);
   ns = ns ?? "Main";
-  const [program] = typecheck(ns, parsed, {}, [], testEntryPoint.type);
+  const [program] = typecheck(ns, parsed, {}, [], [], testEntryPoint.type);
   const out = new Compiler().compile(program, ns);
   return out;
 }
@@ -1529,6 +1530,7 @@ function compileSrcWithDeps(rawProject: Record<string, string>): string {
   const res = typecheckProject(
     parseProject(rawProject),
     [],
+    defaultTraitImpls,
     testEntryPoint.type,
   );
   const Main = res.Main!;
@@ -1567,6 +1569,7 @@ function compileRawProject(
   const typecheckResult = typecheckProject(
     untypedProject,
     [],
+    defaultTraitImpls,
     testEntryPoint.type,
   );
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -211,6 +211,22 @@ export class NonExhaustiveMatch implements ErrorDescription {
   }
 }
 
+export class TraitNotSatified implements ErrorDescription {
+  severity: Severity = "error";
+
+  errorName: string = "Trait not satisfied";
+
+  constructor(
+    public readonly type: Type,
+    public readonly trait: string,
+  ) {}
+
+  shortDescription(): string {
+    const type = typeToString(this.type);
+    return `Cannot satisfy trait ${this.trait} for type ${type}`;
+  }
+}
+
 export class TypeMismatch implements ErrorDescription {
   constructor(
     public expected: Type,

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -404,6 +404,10 @@ describe("type hints", () => {
   test("Fn with many arg", () => {
     expect(`extern let f: Fn(A, B, C) -> Int\n`).toBeFormatted();
   });
+
+  test("type with trait annotations", () => {
+    expect(`extern let f: Fn(a) -> b where a: Show, b: Eq\n`).toBeFormatted();
+  });
 });
 
 describe("type delc", () => {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -464,7 +464,7 @@ function declToDoc(ast: UntypedDeclaration): Doc {
     text(`let ${name}`),
     ast.typeHint === undefined
       ? nil
-      : concat(text(": "), typeAstToDoc(ast.typeHint)),
+      : concat(text(": "), typeAstToDoc(ast.typeHint.mono)),
     ast.extern
       ? nil
       : concat(

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,6 +1,7 @@
 import {
   ConstLiteral,
   MatchPattern,
+  PolyTypeAst,
   TypeAst,
   UntypedDeclaration,
   UntypedExpr,
@@ -405,6 +406,26 @@ function patternToDoc(pattern: MatchPattern): Doc {
   }
 }
 
+function typeHintToDoc(poly: PolyTypeAst): Doc {
+  if (poly.where.length === 0) {
+    return typeAstToDoc(poly.mono);
+  }
+
+  const entries = poly.where
+    .map(({ typeVar, traits }) => [typeVar, traits] as const)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([tVar, traits]) => {
+      const traitsDocs = traits.map((s) => text(s));
+      return concat(text(tVar, ": "), sepBy(text(" + "), traitsDocs));
+    });
+
+  return concat(
+    typeAstToDoc(poly.mono),
+    text(" where "),
+    sepBy(text(", "), entries),
+  );
+}
+
 function typeAstToDoc(typeAst: TypeAst): Doc {
   switch (typeAst.type) {
     case "named": {
@@ -464,7 +485,7 @@ function declToDoc(ast: UntypedDeclaration): Doc {
     text(`let ${name}`),
     ast.typeHint === undefined
       ? nil
-      : concat(text(": "), typeAstToDoc(ast.typeHint.mono)),
+      : concat(text(": "), typeHintToDoc(ast.typeHint)),
     ast.extern
       ? nil
       : concat(

--- a/src/parser/__snapshots__/parser.test.ts.snap
+++ b/src/parser/__snapshots__/parser.test.ts.snap
@@ -167,6 +167,7 @@ exports[`Comments > doc comments on externs 1`] = `
           58,
           59,
         ],
+        "where": [],
       },
     },
   ],
@@ -330,6 +331,7 @@ exports[`extern bindings > let decls 1`] = `
           21,
           24,
         ],
+        "where": [],
       },
     },
   ],
@@ -369,6 +371,7 @@ exports[`extern bindings > let decls defining infix operators 1`] = `
           25,
           36,
         ],
+        "where": [],
       },
     },
   ],
@@ -583,6 +586,7 @@ exports[`imports > parse pub modifier on extern values 1`] = `
           18,
           21,
         ],
+        "where": [],
       },
     },
   ],
@@ -696,6 +700,7 @@ exports[`imports > type defs can be qualified 1`] = `
           14,
           24,
         ],
+        "where": [],
       },
     },
   ],
@@ -4468,6 +4473,14 @@ exports[`traits > parses traits in a polytype 1`] = `
           14,
           15,
         ],
+        "where": [
+          {
+            "traits": [
+              "Ord",
+            ],
+            "typeVar": "a",
+          },
+        ],
       },
     },
   ],
@@ -4833,6 +4846,7 @@ exports[`type hints > parses Fn type with args 1`] = `
           8,
           21,
         ],
+        "where": [],
       },
       "value": {
         "span": [
@@ -4891,6 +4905,7 @@ exports[`type hints > parses Fn type with no args 1`] = `
           8,
           19,
         ],
+        "where": [],
       },
       "value": {
         "span": [
@@ -4941,6 +4956,7 @@ exports[`type hints > parses a concrete type with no args as a type hint 1`] = `
           8,
           11,
         ],
+        "where": [],
       },
       "value": {
         "span": [
@@ -5001,6 +5017,7 @@ exports[`type hints > parses concrete type with 1 arg 1`] = `
           8,
           19,
         ],
+        "where": [],
       },
       "value": {
         "span": [
@@ -5070,6 +5087,7 @@ exports[`type hints > parses concrete type with 2 args 1`] = `
           8,
           25,
         ],
+        "where": [],
       },
       "value": {
         "span": [
@@ -5119,6 +5137,7 @@ exports[`type hints > parses type vars hints 1`] = `
           8,
           9,
         ],
+        "where": [],
       },
       "value": {
         "span": [
@@ -5167,6 +5186,7 @@ exports[`type hints > parses underscore type 1`] = `
           8,
           9,
         ],
+        "where": [],
       },
       "value": {
         "span": [

--- a/src/parser/__snapshots__/parser.test.ts.snap
+++ b/src/parser/__snapshots__/parser.test.ts.snap
@@ -154,13 +154,19 @@ exports[`Comments > doc comments on externs 1`] = `
         59,
       ],
       "typeHint": {
-        "args": [],
-        "name": "X",
+        "mono": {
+          "args": [],
+          "name": "X",
+          "span": [
+            58,
+            59,
+          ],
+          "type": "named",
+        },
         "span": [
           58,
           59,
         ],
-        "type": "named",
       },
     },
   ],
@@ -311,13 +317,19 @@ exports[`extern bindings > let decls 1`] = `
         24,
       ],
       "typeHint": {
-        "args": [],
-        "name": "Int",
+        "mono": {
+          "args": [],
+          "name": "Int",
+          "span": [
+            21,
+            24,
+          ],
+          "type": "named",
+        },
         "span": [
           21,
           24,
         ],
-        "type": "named",
       },
     },
   ],
@@ -344,13 +356,19 @@ exports[`extern bindings > let decls defining infix operators 1`] = `
         36,
       ],
       "typeHint": {
-        "args": [],
-        "name": "ExampleType",
+        "mono": {
+          "args": [],
+          "name": "ExampleType",
+          "span": [
+            25,
+            36,
+          ],
+          "type": "named",
+        },
         "span": [
           25,
           36,
         ],
-        "type": "named",
       },
     },
   ],
@@ -552,13 +570,19 @@ exports[`imports > parse pub modifier on extern values 1`] = `
         21,
       ],
       "typeHint": {
-        "args": [],
-        "name": "Int",
+        "mono": {
+          "args": [],
+          "name": "Int",
+          "span": [
+            18,
+            21,
+          ],
+          "type": "named",
+        },
         "span": [
           18,
           21,
         ],
-        "type": "named",
       },
     },
   ],
@@ -658,14 +682,20 @@ exports[`imports > type defs can be qualified 1`] = `
         24,
       ],
       "typeHint": {
-        "args": [],
-        "name": "MyType",
-        "namespace": "A/B",
+        "mono": {
+          "args": [],
+          "name": "MyType",
+          "namespace": "A/B",
+          "span": [
+            14,
+            24,
+          ],
+          "type": "named",
+        },
         "span": [
           14,
           24,
         ],
-        "type": "named",
       },
     },
   ],
@@ -4408,6 +4438,44 @@ exports[`pipe syntax sugar should handle qualified names 1`] = `
 }
 `;
 
+exports[`traits > parses traits in a polytype 1`] = `
+{
+  "declarations": [
+    {
+      "binding": {
+        "name": "x",
+        "span": [
+          11,
+          12,
+        ],
+      },
+      "extern": true,
+      "pub": false,
+      "span": [
+        0,
+        28,
+      ],
+      "typeHint": {
+        "mono": {
+          "ident": "a",
+          "span": [
+            14,
+            15,
+          ],
+          "type": "var",
+        },
+        "span": [
+          14,
+          15,
+        ],
+      },
+    },
+  ],
+  "imports": [],
+  "typeDeclarations": [],
+}
+`;
+
 exports[`type declarations > many type params 1`] = `
 {
   "declarations": [],
@@ -4725,40 +4793,46 @@ exports[`type hints > parses Fn type with args 1`] = `
         25,
       ],
       "typeHint": {
-        "args": [
-          {
+        "mono": {
+          "args": [
+            {
+              "args": [],
+              "name": "X",
+              "span": [
+                11,
+                12,
+              ],
+              "type": "named",
+            },
+            {
+              "args": [],
+              "name": "Y",
+              "span": [
+                14,
+                15,
+              ],
+              "type": "named",
+            },
+          ],
+          "return": {
             "args": [],
-            "name": "X",
+            "name": "Z",
             "span": [
-              11,
-              12,
+              20,
+              21,
             ],
             "type": "named",
           },
-          {
-            "args": [],
-            "name": "Y",
-            "span": [
-              14,
-              15,
-            ],
-            "type": "named",
-          },
-        ],
-        "return": {
-          "args": [],
-          "name": "Z",
           "span": [
-            20,
+            8,
             21,
           ],
-          "type": "named",
+          "type": "fn",
         },
         "span": [
           8,
           21,
         ],
-        "type": "fn",
       },
       "value": {
         "span": [
@@ -4796,21 +4870,27 @@ exports[`type hints > parses Fn type with no args 1`] = `
         23,
       ],
       "typeHint": {
-        "args": [],
-        "return": {
+        "mono": {
           "args": [],
-          "name": "Int",
+          "return": {
+            "args": [],
+            "name": "Int",
+            "span": [
+              16,
+              19,
+            ],
+            "type": "named",
+          },
           "span": [
-            16,
+            8,
             19,
           ],
-          "type": "named",
+          "type": "fn",
         },
         "span": [
           8,
           19,
         ],
-        "type": "fn",
       },
       "value": {
         "span": [
@@ -4848,13 +4928,19 @@ exports[`type hints > parses a concrete type with no args as a type hint 1`] = `
         15,
       ],
       "typeHint": {
-        "args": [],
-        "name": "Int",
+        "mono": {
+          "args": [],
+          "name": "Int",
+          "span": [
+            8,
+            11,
+          ],
+          "type": "named",
+        },
         "span": [
           8,
           11,
         ],
-        "type": "named",
       },
       "value": {
         "span": [
@@ -4892,23 +4978,29 @@ exports[`type hints > parses concrete type with 1 arg 1`] = `
         23,
       ],
       "typeHint": {
-        "args": [
-          {
-            "args": [],
-            "name": "Int",
-            "span": [
-              15,
-              18,
-            ],
-            "type": "named",
-          },
-        ],
-        "name": "Option",
+        "mono": {
+          "args": [
+            {
+              "args": [],
+              "name": "Int",
+              "span": [
+                15,
+                18,
+              ],
+              "type": "named",
+            },
+          ],
+          "name": "Option",
+          "span": [
+            8,
+            19,
+          ],
+          "type": "named",
+        },
         "span": [
           8,
           19,
         ],
-        "type": "named",
       },
       "value": {
         "span": [
@@ -4946,32 +5038,38 @@ exports[`type hints > parses concrete type with 2 args 1`] = `
         29,
       ],
       "typeHint": {
-        "args": [
-          {
-            "args": [],
-            "name": "Int",
-            "span": [
-              15,
-              18,
-            ],
-            "type": "named",
-          },
-          {
-            "args": [],
-            "name": "Bool",
-            "span": [
-              20,
-              24,
-            ],
-            "type": "named",
-          },
-        ],
-        "name": "Result",
+        "mono": {
+          "args": [
+            {
+              "args": [],
+              "name": "Int",
+              "span": [
+                15,
+                18,
+              ],
+              "type": "named",
+            },
+            {
+              "args": [],
+              "name": "Bool",
+              "span": [
+                20,
+                24,
+              ],
+              "type": "named",
+            },
+          ],
+          "name": "Result",
+          "span": [
+            8,
+            25,
+          ],
+          "type": "named",
+        },
         "span": [
           8,
           25,
         ],
-        "type": "named",
       },
       "value": {
         "span": [
@@ -5009,12 +5107,18 @@ exports[`type hints > parses type vars hints 1`] = `
         13,
       ],
       "typeHint": {
-        "ident": "a",
+        "mono": {
+          "ident": "a",
+          "span": [
+            8,
+            9,
+          ],
+          "type": "var",
+        },
         "span": [
           8,
           9,
         ],
-        "type": "var",
       },
       "value": {
         "span": [
@@ -5052,11 +5156,17 @@ exports[`type hints > parses underscore type 1`] = `
         13,
       ],
       "typeHint": {
+        "mono": {
+          "span": [
+            8,
+            9,
+          ],
+          "type": "any",
+        },
         "span": [
           8,
           9,
         ],
-        "type": "any",
       },
       "value": {
         "span": [

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -4,8 +4,14 @@ export type ConstLiteral =
   | { type: "char"; value: string }
   | { type: "string"; value: string };
 
+export type TraitDef = {
+  typeVar: string;
+  traits: string[];
+};
+
 export type PolyTypeAst<TypeResolutionMeta = unknown> = {
   mono: TypeAst<TypeResolutionMeta>;
+  where: TraitDef[];
 };
 
 export type TypeAst<TypeResolutionMeta = unknown> = SpanMeta &

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -4,6 +4,10 @@ export type ConstLiteral =
   | { type: "char"; value: string }
   | { type: "string"; value: string };
 
+export type PolyTypeAst<TypeResolutionMeta = unknown> = {
+  mono: TypeAst<TypeResolutionMeta>;
+};
+
 export type TypeAst<TypeResolutionMeta = unknown> = SpanMeta &
   (
     | {
@@ -137,12 +141,12 @@ export type Declaration<
 } & (
     | {
         extern: false;
-        typeHint?: TypeAst<TypeResolutionMeta> & SpanMeta;
+        typeHint?: PolyTypeAst<TypeResolutionMeta> & SpanMeta;
         value: Expr<TypeMeta, IdentifierResolutionMeta, SyntaxSugar>;
       }
     | {
         extern: true;
-        typeHint: TypeAst<TypeResolutionMeta> & SpanMeta;
+        typeHint: PolyTypeAst<TypeResolutionMeta> & SpanMeta;
       }
   );
 

--- a/src/parser/grammar.ohm
+++ b/src/parser/grammar.ohm
@@ -9,10 +9,16 @@ Program {
     = (ident | infixIdent) -- value
     | typeIdent ("(" ".." ")")? -- type
 
+  TraitDef
+    = typeVar ":" typeIdent
+
+  PolyType
+    = Type ("where" NonemptyListOf<TraitDef, ","> )?
+
   // --- Toplevel
   Declaration
-    = docCommentLine* "pub"? "let" ident (":" Type)? "=" Exp  -- letStmt
-    | docCommentLine* "extern" "pub"? "let" (ident | infixIdent) ":" Type -- externLetStmt
+    = docCommentLine* "pub"? "let" ident (":" PolyType)? "=" Exp  -- letStmt
+    | docCommentLine* "extern" "pub"? "let" (ident | infixIdent) ":" PolyType -- externLetStmt
 
   TypeDeclaration
     = docCommentLine* ("pub" "(..)"?)? "type" typeIdent ("<" NonemptyListOf<typeVar, ","> ">")? "{" ListOf<TypeVariant, ","> ","? "}" -- typeDef

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -429,6 +429,13 @@ describe("type hints", () => {
   });
 });
 
+describe("traits", () => {
+  test("parses traits in a polytype", () => {
+    const src = "extern let x: a where a: Ord";
+    expect(unsafeParse(src)).toMatchSnapshot();
+  });
+});
+
 describe("type declarations", () => {
   test("type with no variants", () => {
     const src = "type Never { }";

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -12,6 +12,7 @@ import {
   UntypedExposedValue,
   UntypedImport,
   UntypedExpr,
+  PolyTypeAst,
 } from "./ast";
 import type {
   IterationNode,
@@ -422,6 +423,14 @@ semantics.addOperation<{ namespace?: string; name: string }>(
   },
 );
 
+semantics.addOperation<PolyTypeAst>("poly()", {
+  PolyType(type_, _where, _traitDefs) {
+    return {
+      mono: type_.type(),
+    };
+  },
+});
+
 semantics.addOperation<TypeAst>("type()", {
   Type_any(_underscore) {
     return { type: "any", span: getSpan(this) };
@@ -555,6 +564,7 @@ semantics.addOperation<Statement>("statement()", {
       decl,
     };
   },
+
   Declaration_externLetStmt(
     docComments,
     _extern,
@@ -572,7 +582,7 @@ semantics.addOperation<Statement>("statement()", {
       binding: ident.ident(),
       span: getSpan(this),
       typeHint: {
-        ...typeHint.type(),
+        ...typeHint.poly(),
         span: getSpan(typeHint.child(0)),
       },
     };
@@ -609,7 +619,7 @@ semantics.addOperation<Statement>("statement()", {
 
     if (typeHint.numChildren > 0) {
       decl.typeHint = {
-        ...typeHint.child(0).type(),
+        ...typeHint.child(0).poly(),
         span: getSpan(typeHint.child(0)),
       };
     }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -13,6 +13,7 @@ import {
   UntypedImport,
   UntypedExpr,
   PolyTypeAst,
+  TraitDef,
 } from "./ast";
 import type {
   IterationNode,
@@ -423,10 +424,28 @@ semantics.addOperation<{ namespace?: string; name: string }>(
   },
 );
 
+semantics.addOperation<TraitDef>("traitDef()", {
+  TraitDef(typeVar, _colon, trait) {
+    return {
+      typeVar: typeVar.sourceString,
+      traits: [trait.sourceString],
+    };
+  },
+});
+
 semantics.addOperation<PolyTypeAst>("poly()", {
-  PolyType(type_, _where, _traitDefs) {
+  PolyType(type_, _where, traitDefs) {
+    const traits =
+      traitDefs.numChildren === 0
+        ? []
+        : traitDefs
+            .child(0)
+            .asIteration()
+            .children.map((arg) => arg.traitDef());
+
     return {
       mono: type_.type(),
+      where: traits,
     };
   },
 });

--- a/src/typecheck/defaultImports.ts
+++ b/src/typecheck/defaultImports.ts
@@ -99,3 +99,11 @@ export const defaultImports: UntypedImport[] = [
     ],
   },
 ];
+
+export type TraitImpl = {
+  moduleName: string;
+  typeName: string;
+  trait: string;
+};
+
+export const defaultTraitImpls: TraitImpl[] = [];

--- a/src/typecheck/defaultImports.ts
+++ b/src/typecheck/defaultImports.ts
@@ -108,34 +108,25 @@ export type TraitImpl = {
   deps?: TraitImplDependency[];
 };
 
-const Eq = "Eq";
+const Eq = "Eq",
+  Ord = "Ord",
+  Show = "Show";
 
 export const defaultTraitImpls: TraitImpl[] = [
   // Extern types
   { moduleName: "Char", typeName: "Char", trait: Eq },
+  { moduleName: "Char", typeName: "Char", trait: Ord },
+  { moduleName: "Char", typeName: "Char", trait: Show },
+
   { moduleName: "String", typeName: "String", trait: Eq },
+  { moduleName: "String", typeName: "String", trait: Ord },
+  { moduleName: "String", typeName: "String", trait: Show },
+
   { moduleName: "Int", typeName: "Int", trait: Eq },
+  { moduleName: "Int", typeName: "Int", trait: Ord },
+  { moduleName: "Int", typeName: "Int", trait: Show },
+
   { moduleName: "Float", typeName: "Float", trait: Eq },
-
-  // Special compilation mode
-  { moduleName: "Unit", typeName: "Unit", trait: Eq },
-  { moduleName: "Bool", typeName: "Bool", trait: Eq },
-
-  // ADTS
-  { moduleName: "Option", typeName: "Option", trait: Eq, deps: [[Eq]] },
-  { moduleName: "List", typeName: "List", trait: Eq, deps: [[Eq]] },
-  { moduleName: "Result", typeName: "Result", trait: Eq, deps: [[Eq], [Eq]] },
-  { moduleName: "Tuple", typeName: "Tuple2", trait: Eq, deps: [[Eq], [Eq]] },
-  {
-    moduleName: "Tuple",
-    typeName: "Tuple3",
-    trait: Eq,
-    deps: [[Eq], [Eq], [Eq]],
-  },
-  {
-    moduleName: "Tuple",
-    typeName: "Tuple4",
-    trait: Eq,
-    deps: [[Eq], [Eq], [Eq], [Eq]],
-  },
+  { moduleName: "Float", typeName: "Float", trait: Ord },
+  { moduleName: "Float", typeName: "Float", trait: Show },
 ];

--- a/src/typecheck/defaultImports.ts
+++ b/src/typecheck/defaultImports.ts
@@ -1,4 +1,5 @@
 import { Span, UntypedImport } from "../parser";
+import { TraitImplDependency } from "./type";
 
 const dummySpan: Span = [0, 0];
 
@@ -104,6 +105,37 @@ export type TraitImpl = {
   moduleName: string;
   typeName: string;
   trait: string;
+  deps?: TraitImplDependency[];
 };
 
-export const defaultTraitImpls: TraitImpl[] = [];
+const Eq = "Eq";
+
+export const defaultTraitImpls: TraitImpl[] = [
+  // Extern types
+  { moduleName: "Char", typeName: "Char", trait: Eq },
+  { moduleName: "String", typeName: "String", trait: Eq },
+  { moduleName: "Int", typeName: "Int", trait: Eq },
+  { moduleName: "Float", typeName: "Float", trait: Eq },
+
+  // Special compilation mode
+  { moduleName: "Unit", typeName: "Unit", trait: Eq },
+  { moduleName: "Bool", typeName: "Bool", trait: Eq },
+
+  // ADTS
+  { moduleName: "Option", typeName: "Option", trait: Eq, deps: [[Eq]] },
+  { moduleName: "List", typeName: "List", trait: Eq, deps: [[Eq]] },
+  { moduleName: "Result", typeName: "Result", trait: Eq, deps: [[Eq], [Eq]] },
+  { moduleName: "Tuple", typeName: "Tuple2", trait: Eq, deps: [[Eq], [Eq]] },
+  {
+    moduleName: "Tuple",
+    typeName: "Tuple3",
+    trait: Eq,
+    deps: [[Eq], [Eq], [Eq]],
+  },
+  {
+    moduleName: "Tuple",
+    typeName: "Tuple4",
+    trait: Eq,
+    deps: [[Eq], [Eq], [Eq], [Eq]],
+  },
+];

--- a/src/typecheck/resolutionStep.ts
+++ b/src/typecheck/resolutionStep.ts
@@ -192,8 +192,7 @@ class ResolutionStep {
         tDecl.typeHint = {
           mono: this.annotateTypeAst(decl.typeHint.mono),
           span: decl.typeHint.span,
-          // TODO set
-          where: [],
+          where: decl.typeHint.where,
         };
       }
 

--- a/src/typecheck/resolutionStep.ts
+++ b/src/typecheck/resolutionStep.ts
@@ -168,12 +168,14 @@ class ResolutionStep {
           ...decl,
           scheme: {},
           binding,
+          typeHint: undefined!,
         };
       } else {
         tDecl = {
           ...decl,
           scheme: {},
           binding,
+          typeHint: undefined!,
           value: undefined!,
         };
 
@@ -187,7 +189,10 @@ class ResolutionStep {
       }
 
       if (decl.typeHint !== undefined) {
-        tDecl.typeHint = this.annotateTypeAst(decl.typeHint);
+        tDecl.typeHint = {
+          mono: this.annotateTypeAst(decl.typeHint.mono),
+          span: decl.typeHint.span,
+        };
       }
 
       if (!decl.pub) {

--- a/src/typecheck/resolutionStep.ts
+++ b/src/typecheck/resolutionStep.ts
@@ -192,6 +192,8 @@ class ResolutionStep {
         tDecl.typeHint = {
           mono: this.annotateTypeAst(decl.typeHint.mono),
           span: decl.typeHint.span,
+          // TODO set
+          where: [],
         };
       }
 

--- a/src/typecheck/type.test.ts
+++ b/src/typecheck/type.test.ts
@@ -608,6 +608,29 @@ describe("traits", () => {
       }),
     );
   });
+
+  test("fail when trying to unify a tvar with a concrete type that does implement the trait", () => {
+    const $a = TVar.fresh(["ord"]);
+
+    expect(unify($a.asType(), Int)).toEqual<UnifyError>({
+      type: "type-mismatch",
+      left: $a.asType(),
+      right: Int,
+    });
+  });
+
+  test("transitively fail when trying to unify a tvar with a concrete type that does implement the trait", () => {
+    const $a = TVar.fresh();
+    unify($a.asType(), Int);
+
+    const $b = TVar.fresh(["ord"]);
+
+    expect(unify($a.asType(), $b.asType())).toEqual<UnifyError>({
+      type: "type-mismatch",
+      left: $b.asType(),
+      right: Int,
+    });
+  });
 });
 
 function Fn(args: Type[], ret: Type): ConcreteType {

--- a/src/typecheck/type.test.ts
+++ b/src/typecheck/type.test.ts
@@ -629,12 +629,12 @@ describe("traits", () => {
   });
 
   test("fail when trying to unify a tvar with a concrete type that does implement the trait", () => {
-    const $a = TVar.fresh(["ord"]);
+    const $a = TVar.fresh(["Ord"]);
 
     expect(unify($a.asType(), Int)).toEqual<UnifyError>({
-      type: "type-mismatch",
-      left: $a.asType(),
-      right: Int,
+      type: "missing-trait",
+      type_: Int,
+      trait: "Ord",
     });
   });
 
@@ -642,12 +642,12 @@ describe("traits", () => {
     const $a = TVar.fresh();
     unify($a.asType(), Int);
 
-    const $b = TVar.fresh(["ord"]);
+    const $b = TVar.fresh(["Ord"]);
 
     expect(unify($a.asType(), $b.asType())).toEqual<UnifyError>({
-      type: "type-mismatch",
-      left: $b.asType(),
-      right: Int,
+      type: "missing-trait",
+      type_: Int,
+      trait: "Ord",
     });
   });
 
@@ -660,14 +660,14 @@ describe("traits", () => {
   });
 
   test("fails to unify a tvar with a concrete type that implements the trait when type vars don't", () => {
-    TVar.registerTraitImpl(BASICS_MODULE, "List", "ord", [["ord"]]);
+    TVar.registerTraitImpl(BASICS_MODULE, "List", "Ord", [["Ord"]]);
 
-    const $a = TVar.fresh(["ord"]);
+    const $a = TVar.fresh(["Ord"]);
 
     expect(unify($a.asType(), List(Int))).toEqual<UnifyError>({
-      type: "type-mismatch",
-      left: $a.asType(),
-      right: List(Int),
+      type: "missing-trait",
+      type_: List(Int),
+      trait: "Ord",
     });
   });
 
@@ -703,14 +703,14 @@ describe("traits", () => {
     // impl ord for List<a> where a: ord
     // unify(List<a: ord>, List<Int>) => fail
 
-    TVar.registerTraitImpl(BASICS_MODULE, "List", "ord", [["ord"]]);
+    TVar.registerTraitImpl(BASICS_MODULE, "List", "Ord", [["Ord"]]);
 
-    const $a = TVar.fresh(["ord"]);
+    const $a = TVar.fresh(["Ord"]);
 
     expect(unify(List($a.asType()), List(Int))).toEqual<UnifyError>({
-      type: "type-mismatch",
-      left: $a.asType(),
-      right: Int,
+      type: "missing-trait",
+      trait: "Ord",
+      type_: Int,
     });
   });
 

--- a/src/typecheck/type.test.ts
+++ b/src/typecheck/type.test.ts
@@ -14,6 +14,7 @@ import { Bool, Int, List, Option, Tuple } from "../__test__/types";
 
 beforeEach(() => {
   TVar.resetId();
+  TVar.resetTraitImpls();
 });
 
 describe("unify", () => {
@@ -630,6 +631,14 @@ describe("traits", () => {
       left: $b.asType(),
       right: Int,
     });
+  });
+
+  test("succeed to unify a tvar with a concrete type that implements the trait", () => {
+    TVar.registerTraitImpl("Basics", "Int", "ord");
+
+    const $a = TVar.fresh(["ord"]);
+
+    expect(unify($a.asType(), Int)).toEqual(undefined);
   });
 });
 

--- a/src/typecheck/type.test.ts
+++ b/src/typecheck/type.test.ts
@@ -566,6 +566,17 @@ describe(typeToString.name, () => {
     const a = TVar.fresh().asType();
     expect(typeToString(a, {})).toBe("a");
   });
+
+  test("traits", () => {
+    const a = TVar.fresh(["Ord", "Show"]).asType();
+    const b = TVar.fresh().asType();
+    const c = TVar.fresh(["Read"]).asType();
+    const f: Type = { type: "fn", args: [a, b], return: c };
+
+    expect(typeToString(f, {})).toBe(
+      "Fn(a, b) -> c where a: Ord + Show, c: Read",
+    );
+  });
 });
 
 describe("traits", () => {

--- a/src/typecheck/type.test.ts
+++ b/src/typecheck/type.test.ts
@@ -10,7 +10,14 @@ import {
   typeToString,
   unify,
 } from "./type";
-import { Bool, Int, List, Option, Tuple } from "../__test__/types";
+import {
+  BASICS_MODULE,
+  Bool,
+  Int,
+  List,
+  Option,
+  Tuple,
+} from "../__test__/types";
 
 beforeEach(() => {
   TVar.resetId();
@@ -634,11 +641,32 @@ describe("traits", () => {
   });
 
   test("succeed to unify a tvar with a concrete type that implements the trait", () => {
-    TVar.registerTraitImpl("Basics", "Int", "ord");
+    TVar.registerTraitImpl(BASICS_MODULE, "Int", "ord", []);
 
     const $a = TVar.fresh(["ord"]);
 
     expect(unify($a.asType(), Int)).toEqual(undefined);
+  });
+
+  test("fails to unify a tvar with a concrete type that implements the trait when type vars don't", () => {
+    TVar.registerTraitImpl(BASICS_MODULE, "List", "ord", [["ord"]]);
+
+    const $a = TVar.fresh(["ord"]);
+
+    expect(unify($a.asType(), List(Int))).toEqual<UnifyError>({
+      type: "type-mismatch",
+      left: $a.asType(),
+      right: List(Int),
+    });
+  });
+
+  test("succeeds to unify a tvar with a concrete type that implements the trait (including type args)", () => {
+    TVar.registerTraitImpl(BASICS_MODULE, "List", "ord", [["ord"]]);
+    TVar.registerTraitImpl(BASICS_MODULE, "Int", "ord", []);
+
+    const $a = TVar.fresh(["ord"]);
+
+    expect(unify($a.asType(), List(Int))).toEqual(undefined);
   });
 });
 

--- a/src/typecheck/type.test.ts
+++ b/src/typecheck/type.test.ts
@@ -702,6 +702,26 @@ describe("traits", () => {
       right: Int,
     });
   });
+
+  test("generalization and instantiation preserve traits", () => {
+    const initialTraits = ["ord"];
+    const ta = TVar.fresh(initialTraits).asType();
+
+    const scheme = generalizeAsScheme(ta);
+    const taI = instantiateFromScheme(ta, scheme);
+
+    if (taI.type !== "var") {
+      throw new Error();
+    }
+
+    const resolved = taI.var.resolve();
+
+    if (resolved.type !== "unbound") {
+      throw new Error("Expecting an unbound var");
+    }
+
+    expect(resolved.traits).toEqual(initialTraits);
+  });
 });
 
 function Fn(args: Type[], ret: Type): ConcreteType {

--- a/src/typecheck/type.ts
+++ b/src/typecheck/type.ts
@@ -54,6 +54,13 @@ export class TVar {
     return { type: "var", var: this };
   }
 
+  private static concreteTypeImplementsTrait(
+    _t: ConcreteType,
+    _trait: string,
+  ): boolean {
+    return false;
+  }
+
   static unify(t1: Type, t2: Type): UnifyError | undefined {
     // (Var, Var)
     if (t1.type === "var" && t2.type === "var") {
@@ -75,6 +82,17 @@ export class TVar {
         case "bound":
           return TVar.unify(t1.var.value.value, t2);
         case "unbound":
+          for (const trait of t1.var.value.traits) {
+            const impl = TVar.concreteTypeImplementsTrait(t2, trait);
+            // TODO better err
+            if (!impl) {
+              return {
+                type: "type-mismatch",
+                left: t1,
+                right: t2,
+              };
+            }
+          }
           t1.var.value = { type: "bound", value: t2 };
           return;
         case "linked":

--- a/src/typecheck/type.ts
+++ b/src/typecheck/type.ts
@@ -19,7 +19,7 @@ export type Type =
     };
 
 export type TVarResolution =
-  | { type: "unbound"; id: number }
+  | { type: "unbound"; id: number; traits: string[] }
   | { type: "bound"; value: ConcreteType };
 
 export type UnifyError = {
@@ -33,8 +33,8 @@ export class TVar {
     private value: TVarResolution | { type: "linked"; to: TVar },
   ) {}
 
-  static fresh(): TVar {
-    return new TVar({ type: "unbound", id: TVar.unboundId++ });
+  static fresh(traits: string[] = []): TVar {
+    return new TVar({ type: "unbound", id: TVar.unboundId++, traits });
   }
 
   resolve(): TVarResolution {
@@ -147,6 +147,13 @@ export class TVar {
     if (r1.type === "unbound" && r2.type === "unbound" && r1.id === r2.id) {
       // TVars are already linked
       return;
+    }
+
+    // Unify traits
+    for (const t of r2.traits) {
+      if (!r1.traits.includes(t)) {
+        r1.traits.push(t);
+      }
     }
 
     $2.value = { type: "linked", to: $1 };

--- a/src/typecheck/type.ts
+++ b/src/typecheck/type.ts
@@ -172,9 +172,9 @@ export class TVar {
           return TVar.unify(t1.var.value.value, t2);
         case "unbound":
           for (const trait of t1.var.value.traits) {
-            const impl = TVar.typeImplementsTrait(t2, trait);
+            const deps = TVar.typeImplementsTrait(t2, trait);
             // TODO better err
-            if (impl === undefined) {
+            if (deps === undefined) {
               return {
                 type: "type-mismatch",
                 left: t1,
@@ -182,9 +182,9 @@ export class TVar {
               };
             }
 
-            for (const i of impl) {
-              if (!i.traits.includes(trait)) {
-                i.traits.push(trait);
+            for (const dep of deps) {
+              if (!dep.traits.includes(trait)) {
+                dep.traits.push(trait);
               }
             }
           }

--- a/src/typecheck/type.ts
+++ b/src/typecheck/type.ts
@@ -100,8 +100,15 @@ export class TVar {
 
       const arg = t.args[i]!;
 
-      // TODO unify var
       if (arg.type === "var") {
+        const resolved = arg.var.resolve();
+        if (resolved.type === "unbound") {
+          if (!resolved.traits.includes(trait)) {
+            resolved.traits.push(trait);
+          }
+        }
+        // Is the `else` branch unreachable?
+
         return true;
       }
 

--- a/src/typecheck/type.ts
+++ b/src/typecheck/type.ts
@@ -22,11 +22,10 @@ export type TVarResolution =
   | { type: "unbound"; id: number; traits: string[] }
   | { type: "bound"; value: ConcreteType };
 
-export type UnifyError = {
-  type: UnifyErrorType;
-  left: Type;
-  right: Type;
-};
+export type UnifyError =
+  | { type: "type-mismatch"; left: Type; right: Type }
+  | { type: "occurs-check"; left: Type; right: Type }
+  | { type: "missing-trait"; type_: Type; trait: string };
 
 function getNamedTypeTraitId(
   moduleName: string,
@@ -173,12 +172,12 @@ export class TVar {
         case "unbound":
           for (const trait of t1.var.value.traits) {
             const deps = TVar.typeImplementsTrait(t2, trait);
-            // TODO better err
+            // TODO better err: should narrow this error to missing constraint source
             if (deps === undefined) {
               return {
-                type: "type-mismatch",
-                left: t1,
-                right: t2,
+                type: "missing-trait",
+                type_: t2,
+                trait,
               };
             }
 
@@ -274,8 +273,6 @@ export class TVar {
     return undefined;
   }
 }
-
-export type UnifyErrorType = "type-mismatch" | "occurs-check";
 
 export const unify = TVar.unify;
 

--- a/src/typecheck/type.ts
+++ b/src/typecheck/type.ts
@@ -405,7 +405,7 @@ export function instantiateFromScheme(mono: Type, scheme: TypeScheme): Type {
               return i.asType();
             }
 
-            const t = TVar.fresh(resolved.traits);
+            const t = TVar.fresh([...resolved.traits]);
             instantiated.set(boundId, t);
             return t.asType();
           }

--- a/src/typecheck/type.ts
+++ b/src/typecheck/type.ts
@@ -499,12 +499,19 @@ export function typeToString(t: Type, scheme?: TypeScheme): string {
 
   const sortedTraits = Object.entries(traits)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => {
+    .flatMap(([k, v]) => {
+      if (v.size === 0) {
+        return [];
+      }
+
       const sortedTraits = [...v].sort().join(" + ");
 
-      return `${k}: ${sortedTraits}`;
-    })
-    .join(",");
+      return [`${k}: ${sortedTraits}`];
+    });
 
-  return `${ret} where ${sortedTraits}`;
+  if (sortedTraits.length === 0) {
+    return ret;
+  }
+
+  return `${ret} where ${sortedTraits.join(", ")}`;
 }

--- a/src/typecheck/typecheck.test.ts
+++ b/src/typecheck/typecheck.test.ts
@@ -570,6 +570,41 @@ describe("traits", () => {
     );
     expect(errs).toEqual([]);
   });
+
+  test("propagates the trait constraint", () => {
+    const [types, errs] = tc(
+      `
+        extern type String
+        extern let show: Fn(a) -> String where a: Show
+
+        pub let use_show = fn value {
+          show(value)
+        }
+      `,
+    );
+    expect(errs).toEqual([]);
+    expect(types).toEqual({
+      show: "Fn(a) -> String where a: Show",
+      use_show: "Fn(a) -> String where a: Show",
+    });
+  });
+
+  test("fails to typecheck when unify occurs later", () => {
+    const [, errs] = tc(
+      `
+        extern type String
+        extern let show: Fn(a) -> String where a: Show
+
+        extern type Int
+        extern pub let (+): Fn(Int, Int) -> Int
+        pub let f = fn x {
+          let _ = show(x);
+          x + 1
+        }
+      `,
+    );
+    expect(errs).not.toEqual([]);
+  });
 });
 
 describe("custom types", () => {

--- a/src/typecheck/typecheck.test.ts
+++ b/src/typecheck/typecheck.test.ts
@@ -627,7 +627,7 @@ describe("traits", () => {
     );
   });
 
-  test.todo("does not break generalization", () => {
+  test("does not break generalization", () => {
     const [types, errs] = tc(
       `
         extern type Unit

--- a/src/typecheck/typecheck.test.ts
+++ b/src/typecheck/typecheck.test.ts
@@ -561,6 +561,19 @@ describe("traits", () => {
       x: "String",
     });
   });
+
+  test("succeeds to typecheck when a required trait is not implemented", () => {
+    TVar.registerTraitImpl("Int", "Int", "Show", []);
+
+    const [, errs] = tc(
+      `
+        extern type String
+        extern pub let show: Fn(a) -> String where a: Show
+        pub let x = show(42)
+      `,
+    );
+    expect(errs).toEqual([]);
+  });
 });
 
 describe("custom types", () => {

--- a/src/typecheck/typecheck.test.ts
+++ b/src/typecheck/typecheck.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, beforeEach } from "vitest";
 import { unsafeParse, UntypedImport } from "../parser";
 import {
   Deps,
@@ -29,6 +29,12 @@ import {
   UnusedImport,
   UnusedVariable,
 } from "../errors";
+import { TVar } from "./type";
+
+beforeEach(() => {
+  TVar.resetId();
+  TVar.resetTraitImpls();
+});
 
 test("infer int", () => {
   const [types, errors] = tc(`
@@ -536,6 +542,23 @@ describe("type hints", () => {
     expect(errs[0]!.description).toBeInstanceOf(UnboundType);
     expect(types).toEqual({
       x: "Int",
+    });
+  });
+});
+
+describe("traits", () => {
+  test("fails to typecheck when a required trait is not implemented", () => {
+    const [types, errs] = tc(
+      `
+        extern type String
+        extern pub let show: Fn(a) -> String where a: Show
+        pub let x = show(42)
+      `,
+    );
+    expect(errs).toHaveLength(1);
+    expect(types).toEqual({
+      show: "Fn(a) -> String where a: Show",
+      x: "String",
     });
   });
 });

--- a/src/typecheck/typecheck.test.ts
+++ b/src/typecheck/typecheck.test.ts
@@ -605,6 +605,50 @@ describe("traits", () => {
     );
     expect(errs).not.toEqual([]);
   });
+
+  test("infers multiple traits", () => {
+    const [types, errs] = tc(
+      `
+        extern type Unit
+        extern let show: Fn(a) -> Unit where a: Show
+        extern let eq: Fn(a) -> Unit where a: Eq
+
+        pub let f = fn x {
+          let _ = show(x);
+          eq(x)
+        }
+      `,
+    );
+    expect(errs).toEqual([]);
+    expect(types).toEqual(
+      expect.objectContaining({
+        f: "Fn(a) -> Unit where a: Eq + Show",
+      }),
+    );
+  });
+
+  test.todo("does not break generalization", () => {
+    const [types, errs] = tc(
+      `
+        extern type Unit
+        extern let show: Fn(a) -> Unit where a: Show
+        extern let eq: Fn(a) -> Unit where a: Eq
+
+        pub let f = fn x {
+          let _ = show(x);
+          let _ = eq(x);
+          0
+        }
+      `,
+    );
+    expect(errs).toEqual([]);
+    expect(types).toEqual(
+      expect.objectContaining({
+        eq: "Fn(a) -> Unit where a: Eq",
+        show: "Fn(a) -> Unit where a: Show",
+      }),
+    );
+  });
 });
 
 describe("custom types", () => {

--- a/src/typecheck/typecheck.ts
+++ b/src/typecheck/typecheck.ts
@@ -277,7 +277,7 @@ class Typechecker {
     if (decl.typeHint !== undefined) {
       const bound: Record<string, TVar> = {};
       const th = this.typeAstToType(
-        decl.typeHint,
+        decl.typeHint.mono,
         { type: "type-hint" },
         bound,
       );

--- a/src/typecheck/typecheck.ts
+++ b/src/typecheck/typecheck.ts
@@ -54,7 +54,12 @@ export function typecheck(
 ): [TypedModule, ErrorInfo[]] {
   TVar.resetTraitImpls();
   for (const impl of traitImpls) {
-    TVar.registerTraitImpl(impl.moduleName, impl.typeName, impl.trait, []);
+    TVar.registerTraitImpl(
+      impl.moduleName,
+      impl.typeName,
+      impl.trait,
+      impl.deps ?? [],
+    );
   }
 
   return new Typechecker(ns, mainType).run(module, deps, implicitImports);

--- a/src/typecheck/typecheck.ts
+++ b/src/typecheck/typecheck.ts
@@ -34,6 +34,7 @@ import {
   InvalidTypeArity,
   NonExhaustiveMatch,
   OccursCheck,
+  TraitNotSatified,
   TypeMismatch,
   UnboundTypeParam,
 } from "../errors";
@@ -226,6 +227,7 @@ class Typechecker {
     }
 
     if (
+      e.type === "type-mismatch" &&
       e.left.type === "fn" &&
       e.right.type === "fn" &&
       e.left.args.length !== e.right.args.length
@@ -648,6 +650,12 @@ export type ProjectTypeCheckResult = Record<string, [TypedModule, ErrorInfo[]]>;
 
 function unifyErr(node: SpanMeta, e: UnifyError): ErrorInfo {
   switch (e.type) {
+    case "missing-trait":
+      return {
+        span: node.span,
+        description: new TraitNotSatified(e.type_, e.trait),
+      };
+
     case "type-mismatch":
       return {
         span: node.span,

--- a/src/typecheck/typecheck.ts
+++ b/src/typecheck/typecheck.ts
@@ -14,7 +14,7 @@ import {
   TypedModule,
   TypedTypeAst,
 } from "./typedAst";
-import { defaultImports } from "./defaultImports";
+import { TraitImpl, defaultImports, defaultTraitImpls } from "./defaultImports";
 import {
   TVar,
   Type,
@@ -49,8 +49,14 @@ export function typecheck(
   module: UntypedModule,
   deps: Deps = {},
   implicitImports: UntypedImport[] = defaultImports,
+  traitImpls: TraitImpl[] = defaultTraitImpls,
   mainType = DEFAULT_MAIN_TYPE,
 ): [TypedModule, ErrorInfo[]] {
+  TVar.resetTraitImpls();
+  for (const impl of traitImpls) {
+    TVar.registerTraitImpl(impl.moduleName, impl.typeName, impl.trait, []);
+  }
+
   return new Typechecker(ns, mainType).run(module, deps, implicitImports);
 }
 
@@ -545,6 +551,7 @@ export type UntypedProject = Record<
 export function typecheckProject(
   project: UntypedProject,
   implicitImports: UntypedImport[] = defaultImports,
+  traitImpls: TraitImpl[] = defaultTraitImpls,
   mainType = DEFAULT_MAIN_TYPE,
 ): ProjectTypeCheckResult {
   const sortedModules = topSortedModules(project, implicitImports);
@@ -562,6 +569,7 @@ export function typecheckProject(
       m.module,
       deps,
       m.package === CORE_PACKAGE ? [] : implicitImports,
+      traitImpls,
       mainType,
     );
     projectResult[ns] = tc;

--- a/src/typecheck/typedAst/gotoDefinition.test.ts
+++ b/src/typecheck/typedAst/gotoDefinition.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "vitest";
+import { test, expect, beforeEach } from "vitest";
 import { goToDefinitionOf, Location } from "../typedAst";
 import { unsafeParse } from "../../parser";
-import { typecheck } from "../typecheck";
+import { resetTraitsRegistry, typecheck } from "../typecheck";
 import { indexOf, spanOf } from "./__test__/utils";
 
 test("glb decl", () => {
@@ -122,8 +122,11 @@ function parseGotoDef(
   if (offset === undefined) {
     throw new Error("Invalid offset");
   }
-
   const parsed = unsafeParse(src);
   const [typed, _] = typecheck("Main", parsed);
   return goToDefinitionOf(typed, offset);
 }
+
+beforeEach(() => {
+  resetTraitsRegistry();
+});

--- a/src/typecheck/typedAst/gotoDefinition.ts
+++ b/src/typecheck/typedAst/gotoDefinition.ts
@@ -26,7 +26,7 @@ export function goToDefinitionOf(
     case "declaration":
       if (statement.declaration.typeHint !== undefined) {
         const ret = goToDefinitionOfTypeAst(
-          statement.declaration.typeHint,
+          statement.declaration.typeHint.mono,
           offset,
         );
         if (ret !== undefined) {

--- a/src/typecheck/typedAst/hoverOn.test.ts
+++ b/src/typecheck/typedAst/hoverOn.test.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "vitest";
+import { test, expect, beforeEach } from "vitest";
 import { Hovered, hoverOn, hoverToMarkdown } from "../typedAst";
 import { unsafeParse } from "../../parser";
-import { typecheck } from "../typecheck";
+import { resetTraitsRegistry, typecheck } from "../typecheck";
 import { TypeScheme } from "../type";
 import { indexOf, spanOf } from "./__test__/utils";
 
@@ -305,3 +305,7 @@ function parseHover(
   }
   return ret;
 }
+
+beforeEach(() => {
+  resetTraitsRegistry();
+});

--- a/src/typecheck/typedAst/hoverOn.ts
+++ b/src/typecheck/typedAst/hoverOn.ts
@@ -29,7 +29,7 @@ export function hoverOn(
   switch (statement.type) {
     case "declaration": {
       if (statement.declaration.typeHint !== undefined) {
-        const res = hoverOnTypeAst(statement.declaration.typeHint, offset);
+        const res = hoverOnTypeAst(statement.declaration.typeHint.mono, offset);
         if (res !== undefined) {
           return res;
         }


### PR DESCRIPTION
Implementation of a subset of Haskell's type classes
Syntax:

```rust
// trait definition: no syntax (a fixed amount of traits exists, and are hardcoded into the compiler)
// impl: no syntax (impl is hardcoded in the compiler for primitives, and recursively derived for ADTs)

// type signature
let expect_equal: Fn(a, a) -> Expectation where a: Show + Eq
```
